### PR TITLE
Chore: Add DCO sign-off requirement

### DIFF
--- a/.github/workflows/tag-push.yaml
+++ b/.github/workflows/tag-push.yaml
@@ -1,0 +1,48 @@
+---
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 The Linux Foundation
+
+# Runs on tag push, promotes draft release
+name: 'Release on Tag Push 🚀'
+
+# yamllint disable-line rule:truthy
+on:
+  push:
+    tags:
+      # Triggered only by semantic tags push
+      - '**'
+
+permissions: {}
+
+jobs:
+  promote-release:
+    name: 'Promote Draft Release'
+    # yamllint disable-line rule:line-length
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: 'ubuntu-24.04'
+    permissions:
+      contents: write
+    timeout-minutes: 3
+    steps:
+      # Harden the runner used by this workflow
+      # yamllint disable-line rule:line-length
+      - uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863  # v2.12.1
+        with:
+          egress-policy: audit
+
+      # yamllint disable-line rule:line-length
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: 'Verify Pushed Tag'
+        # yamllint disable-line rule:line-length
+        uses: lfreleng-actions/tag-push-verify-action@f9c6e753870c6405883be2ba18af05d075aaffe8  # v0.1.0
+        with:
+          versioning: 'semver'
+
+      - name: 'Promote draft release'
+        # yamllint disable-line rule:line-length
+        uses: lfreleng-actions/draft-release-promote-action@d7e7df12e32fa26b28dbc2f18a12766482785399  # v0.1.2
+        with:
+          token: "${{ secrets.GITHUB_TOKEN }}"
+          tag: "${{ github.ref_name }}"
+          latest: true

--- a/.gitlint
+++ b/.gitlint
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 The Linux Foundation
+
+# All these sections are optional, edit this file as you like.
+[general]
+# Ignore certain rules, you can reference them by their id or by their full
+# name
+# ignore=title-trailing-punctuation, T3
+
+# verbosity should be a value between 1 and 3, the command line -v flags take
+# precedence over this
+# verbosity = 2
+
+# By default gitlint will ignore merge commits. Set to 'false' to disable.
+# ignore-merge-commits=true
+
+# By default gitlint will ignore fixup commits. Set to 'false' to disable.
+# ignore-fixup-commits=true
+
+# By default gitlint will ignore squash commits. Set to 'false' to disable.
+# ignore-squash-commits=true
+
+# Enable debug mode (prints more output). Disabled by default.
+# debug=true
+
+# Set the extra-path where gitlint will search for user defined rules
+# See http://jorisroovers.github.io/gitlint/user_defined_rules for details
+# extra-path=examples/
+
+contrib=contrib-title-conventional-commits,contrib-body-requires-signed-off-by
+
+[contrib-title-conventional-commits]
+types=Fix,Feat,Chore,Docs,Style,Refactor,Perf,Test,Revert,CI,Build
+
+# Disable linting on lines that have URLs on them
+[ignore-body-lines]
+regex=(.*)https?://(.*)


### PR DESCRIPTION
Add Developer Certificate of Origin checking to ensure all
commits include proper sign-off as required by Linux Foundation projects.

This adds DCO sign-off requirement via gitlint configuration and
pre-commit hook to enforce DCO on all commits.