### PR TITLE
CI: Address Zizmor scan findings in testing workflow

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -39,6 +39,8 @@ jobs:
       - name: 'Checkout repository'
         # yamllint disable-line rule:line-length
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       # Install required dependencies
       - name: 'Install Helm'
@@ -93,7 +95,7 @@ jobs:
       # Upload the built chart as an artifact
       - name: 'Upload Helm Chart Artifact'
         # yamllint disable-line rule:line-length
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.1
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: helm-chart
           path: ${{ env.CHART_NAME }}


### PR DESCRIPTION
## Summary

Resolves two Zizmor audit warnings flagged on the `.github/workflows/testing.yaml` workflow.

### `zizmor/artipacked` — credential persistence

The `actions/checkout` step did not disable credential persistence, allowing the `GITHUB_TOKEN` to be written to the local git config and risk exposure through uploaded artifacts. No subsequent step requires the token, so `persist-credentials: false` is now set.

### `zizmor/ref-version-mismatch` — mismatched pin comment

The `actions/upload-artifact` pin comment claimed `v4.6.1`, but the commit SHA `ea165f8d65b6e75b540449e92b4886f43607fa02` actually corresponds to `v4.6.2`. The version comment has been corrected to match the pinned commit (verified via `git ls-remote --tags`).

## Changes

```diff
       - name: 'Checkout repository'
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false

       - name: 'Upload Helm Chart Artifact'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.1
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
```
