### PR TITLE
CI: Enable Dependabot for GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+---
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+# Dependabot configuration
+# Keeps GitHub Actions pinned to commit SHAs up-to-date automatically.
+# Dependabot preserves the existing pin style, so SHA-pinned actions
+# remain SHA-pinned (with the accompanying version comment refreshed).
+# Reference:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  # Maintain GitHub Actions used by workflows in .github/workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "CI(actions)"
+    # Wait before opening a bump PR so we don't churn on a release
+    # that gets retracted or superseded shortly after it ships.
+    # This is required to satisfy the zizmor workflow auditing tool.
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 15


### PR DESCRIPTION
## Summary

Enables Dependabot so GitHub Actions calls are kept up-to-date automatically. Dependabot preserves the existing pinning style, so SHA-pinned actions stay pinned to commit SHAs while their accompanying version comments are refreshed on each update.

## Convention alignment

The configuration follows the established convention from the `actions-template` repository:

- `.github/dependabot.yml` filename
- `CI(actions)` Conventional Commit prefix
- `cooldown.default-days: 7` — delays bump PRs so the repo does not churn on a release that is retracted or superseded shortly after it ships (this also satisfies the Zizmor workflow auditing tool)
- `open-pull-requests-limit: 15`

## Config

```yaml
version: 2
updates:
  - package-ecosystem: "github-actions"
    directory: "/"
    schedule:
      interval: "weekly"
    commit-message:
      prefix: "CI(actions)"
    cooldown:
      default-days: 7
    open-pull-requests-limit: 15
```
