### PR TITLE
CI: Clear Zizmor auditor findings in workflows

### DIFF
--- a/.github/workflows/tag-push.yaml
+++ b/.github/workflows/tag-push.yaml
@@ -11,6 +11,11 @@ on:
     tags:
       - '**'
 
+# Serialise release runs per tag; do not cancel an in-progress release
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: false
+
 permissions: {}
 
 jobs:
@@ -20,7 +25,7 @@ jobs:
     if: "!github.event.deleted"
     runs-on: 'ubuntu-latest'
     permissions:
-      contents: read
+      contents: read  # Read repository contents for tag validation
     timeout-minutes: 5
     outputs:
       tag: "${{ steps.tag_validate.outputs.tag_name }}"
@@ -53,7 +58,7 @@ jobs:
     needs: validate_tag
     runs-on: 'ubuntu-latest'
     permissions:
-      contents: write
+      contents: write  # Promote (publish) the draft GitHub release
     timeout-minutes: 5
     steps:
       # Harden the runner used by this workflow

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -68,13 +68,13 @@ jobs:
       - name: 'Validate Helm Chart'
         run: |
           # Check if the expected artifact was created
-          if [[ -f "${{ env.CHART_NAME }}" ]]; then
-            echo "✅ Chart package created: ${{ env.CHART_NAME }}"
-            echo "✅ Chart package created: ${{ env.CHART_NAME }}" \
+          if [[ -f "$CHART_NAME" ]]; then
+            echo "✅ Chart package created: $CHART_NAME"
+            echo "✅ Chart package created: $CHART_NAME" \
               >> "$GITHUB_STEP_SUMMARY"
 
             # Show package details
-            ls -la "${{ env.CHART_NAME }}"
+            ls -la "$CHART_NAME"
 
             # Lint the chart
             helm lint charts/test-chart
@@ -86,8 +86,8 @@ jobs:
             echo "✅ Chart validation completed successfully" \
               >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "❌ Chart package not found: ${{ env.CHART_NAME }}"
-            echo "❌ Chart package not found: ${{ env.CHART_NAME }}" \
+            echo "❌ Chart package not found: $CHART_NAME"
+            echo "❌ Chart package not found: $CHART_NAME" \
               >> "$GITHUB_STEP_SUMMARY"
             exit 1
           fi


### PR DESCRIPTION
## Summary

Runs the [Zizmor](https://github.com/woodruffw/zizmor) static analysis
tool against the GitHub Actions workflows using the **auditor** persona
and resolves **all** reported findings, across every severity level
(informational, low, medium, high), unconditionally.

Before this change, `zizmor --persona=auditor .github/workflows/`
reported 8 findings; afterwards it reports **"No findings to report"**.

## Changes

### `.github/workflows/testing.yaml`
- Replace the GitHub Actions template expansions of the workflow-level
  `CHART_NAME` variable (`${{ env.CHART_NAME }}`) inside `run:` blocks
  with the shell environment variable (`$CHART_NAME`). The value is
  already exported to the runner via the workflow-level `env:` block, so
  behaviour is unchanged while the `template-injection` findings are
  eliminated.

### `.github/workflows/tag-push.yaml`
- Add a workflow-level `concurrency` group keyed on the workflow and ref
  so release runs are serialised per tag. `cancel-in-progress` is set to
  `false` to avoid interrupting an in-progress release
  (`concurrency-limits`).
- Add inline explanatory comments to the job-level `permissions` entries
  to satisfy the `undocumented-permissions` audit.

## Validation
- `zizmor --persona=auditor --offline .github/workflows/` → no findings
- `prek run` on both workflow files (yamllint, actionlint, reuse, etc.) → all pass
